### PR TITLE
Fix ember-date 1.13 DEPRECATION: Calling store.find() with a query ob…

### DIFF
--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -73,7 +73,7 @@ export default Ember.ArrayProxy.extend(PageMixin, Ember.Evented, ArrayProxyPromi
     var modelName = this.get('modelName');
 
     var ops = this.get('paramsForBackend');
-    var res = store.find(modelName, ops);
+    var res = store.query(modelName, ops);
 
     return res;
   },


### PR DESCRIPTION
…ject is deprecated. Use store.query() instead.