### PR TITLE
Fixes a 'infinite' loop in tests due to possible ember-data lifecycle…

### DIFF
--- a/tests/dummy/app/initializers/ember-data-3-hack.js
+++ b/tests/dummy/app/initializers/ember-data-3-hack.js
@@ -1,0 +1,19 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export function initialize(/* application */) {
+  //ember-data 3-3.12 has a bug that results in an explosive dependency update issue on application destroy
+  //this work around fixes that 'infinite' loop
+  if (DS.VERSION.match(/^3\.(\d|1[012])(\..*)?$/)) {
+    DS.RecordArray.reopen({
+      _removeInternalModels(internalModels) {
+        if (!this.isDestroying)
+          Ember.get(this, 'content').removeObjects(internalModels);
+      }
+    })
+  }
+}
+
+export default {
+  initialize
+};


### PR DESCRIPTION
… bug on app.destroy